### PR TITLE
Fix minor inconsistencies in the new savestate system

### DIFF
--- a/src/sound/ym2612.c
+++ b/src/sound/ym2612.c
@@ -2313,7 +2313,6 @@ int YM2612SaveContext(unsigned char *state)
 void gwenesis_ym2612_save_state() {
   SaveState* state;
   state = saveGwenesisStateOpenForWrite("ym2612");
-  saveGwenesisStateSetBuffer(state, "lfo_pm_table", lfo_pm_table, sizeof(lfo_pm_table));
   saveGwenesisStateSetBuffer(state, "ym2612", &ym2612, sizeof(ym2612));
   saveGwenesisStateSet(state, "m2", m2);
   saveGwenesisStateSet(state, "c1", c1);
@@ -2326,7 +2325,6 @@ void gwenesis_ym2612_save_state() {
 
 void gwenesis_ym2612_load_state() {
   SaveState* state = saveGwenesisStateOpenForRead("ym2612");
-  saveGwenesisStateGetBuffer(state, "lfo_pm_table", lfo_pm_table, sizeof(lfo_pm_table));
   saveGwenesisStateGetBuffer(state, "ym2612", &ym2612, sizeof(ym2612));
   m2 = saveGwenesisStateGet(state, "m2");
   c1 = saveGwenesisStateGet(state, "c1");

--- a/src/vdp/gwenesis_vdp_mem.c
+++ b/src/vdp/gwenesis_vdp_mem.c
@@ -1159,7 +1159,7 @@ void gwenesis_vdp_write_memory_16(unsigned int address, unsigned int value) {
 void gwenesis_vdp_mem_save_state() {
   SaveState* state;
   state = saveGwenesisStateOpenForWrite("vdp_mem");
-  saveGwenesisStateSetBuffer(state, "emulator_framebuffer", emulator_framebuffer, sizeof(emulator_framebuffer));
+  saveGwenesisStateSetBuffer(state, "VRAM", VRAM, VRAM_MAX_SIZE);
   saveGwenesisStateSetBuffer(state, "CRAM", CRAM, sizeof(CRAM));
   saveGwenesisStateSetBuffer(state, "SAT_CACHE", SAT_CACHE, sizeof(SAT_CACHE));
   saveGwenesisStateSetBuffer(state, "gwenesis_vdp_regs", gwenesis_vdp_regs, sizeof(gwenesis_vdp_regs));
@@ -1179,7 +1179,7 @@ void gwenesis_vdp_mem_save_state() {
 
 void gwenesis_vdp_mem_load_state() {
   SaveState* state = saveGwenesisStateOpenForRead("vdp_mem");
-  saveGwenesisStateGetBuffer(state, "emulator_framebuffer", emulator_framebuffer, sizeof(emulator_framebuffer));
+  saveGwenesisStateGetBuffer(state, "VRAM", VRAM, VRAM_MAX_SIZE);
   saveGwenesisStateGetBuffer(state, "CRAM", CRAM, sizeof(CRAM));
   saveGwenesisStateGetBuffer(state, "SAT_CACHE", SAT_CACHE, sizeof(SAT_CACHE));
   saveGwenesisStateGetBuffer(state, "gwenesis_vdp_regs", gwenesis_vdp_regs, sizeof(gwenesis_vdp_regs));


### PR DESCRIPTION
This patch does two things:
- Removes `lfo_pm_table`: It is not necessary to save, as it is constant after its generation during boot. It is also quite big, which matter on slow storage access.
- Renames `emulator_framebuffer` to VRAM: emulator_framebuffer is specific to the G&W and also it just makes more sense to label VRAM as, you know, VRAM.